### PR TITLE
fix null pointer & rebuild

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -40395,7 +40395,7 @@ const archiveFilePath = cacheFile();
         const packageYml = await readPackageYml(packageDir);
         const packageVersion = packageYml.version;
         const packageName = packageYml.package;
-        const packageInstallerIgnore = packageYml.installer_ignore;
+        const packageInstallerIgnore = packageYml.installer_ignore || [];
         await zip(archiveFilePath, packageDir, packageName, packageInstallerIgnore);
         const archiveMd5 = await md5_file(archiveFilePath);
         core.info(`Created zip file md5: ${archiveMd5}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ const archiveFilePath = cacheFile();
         const packageYml = await readPackageYml(packageDir);
         const packageVersion = packageYml.version;
         const packageName = packageYml.package;
-        const packageInstallerIgnore = packageYml.installer_ignore;
+        const packageInstallerIgnore = packageYml.installer_ignore || [];
 
         await zip(archiveFilePath, packageDir, packageName, packageInstallerIgnore);
         const archiveMd5 = await md5_file(archiveFilePath);

--- a/src/package.ts
+++ b/src/package.ts
@@ -8,7 +8,7 @@ import crypto from "crypto";
 interface PackageYml {
     package: string;
     version: string;
-    installer_ignore: string[];
+    installer_ignore: string[]|null;
 }
 
 export async function readPackageYml(addonDir: string): Promise<PackageYml> {


### PR DESCRIPTION
fixes #13 

Der Fehler trat auf, wenn es keine `installer_ignore` im der package.yml gibt.