### PR TITLE
improve yaml handling

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -15,7 +15,31 @@ export async function readPackageYml(addonDir: string): Promise<PackageYml> {
     const packageYmlPath = path.join(addonDir, '/', 'package.yml');
     Core.info(`Parsing yaml from ${packageYmlPath}`);
     const packageYmlString = fs.readFileSync(packageYmlPath, {encoding: 'utf8'});
-    return YAML.parse(packageYmlString);
+
+    try {
+        return YAML.parse(packageYmlString, {
+            prettyErrors: true,
+        });
+    } catch (originalError) {
+        Core.error(`Failed to parse yaml from ${packageYmlPath}. Try to fix it automatically.`);
+
+        // try to escape "perm" value
+        const fixedPackageYmlString = packageYmlString.replace(/(perm:[.\s\n\r\t]*)([a-z0-9_]+\[[a-z0-9_]+\])/ig, `$1'$2'`);
+
+        // second try with escaped "perm" value
+        try {
+            const parsedYaml = YAML.parse(fixedPackageYmlString, {
+                prettyErrors: true,
+            });
+            Core.info(`Successfully parsed yaml with fixed values.`);
+
+            return parsedYaml;
+        } catch (_) {
+            // failed to parse yaml with fixed values
+            Core.error(`Automatically fixed yaml failed. Please fix it manually.`);
+            throw originalError;
+        }
+    }
 }
 
 export function md5_file(file: string): Promise<string> {


### PR DESCRIPTION
include source in error message, e.g.
```
::error::YAMLSemanticError: Separator , missing in flow map at line 12, column 122:%0A%0A… rex-icon rex-icon-install, itemclass: pull-right, perm: d2u_staff[settings ] }%0A                                                                   ^^^^^^^^^^^^%0A
(node:21487) UnhandledPromiseRejectionWarning: YAMLSemanticError: Separator , missing in flow map at line 12, column 122:

… rex-icon rex-icon-install, itemclass: pull-right, perm: d2u_staff[settings ] }
                                                                   ^^^^^^^^^^^^

```