### PR TITLE
use `actions/checkout@v3` in example workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ jobs:
   redaxo_publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: FriendsOfREDAXO/installer-action@v1
       with:
         myredaxo-username: ${{ secrets.MYREDAXO_USERNAME }}


### PR DESCRIPTION
`Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2`

closes #108 