### PR TITLE
actions: fix deprecation for git retag workflow

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -32,7 +32,7 @@ jobs:
         id: major-version
         run: |
           MAJOR_VERSION=`cut -d '.' -f 1 <<< "${{ env.TAG_NAME }}"`
-          echo "::set-output name=VERSION::v$MAJOR_VERSION"
+          echo "VERSION=v$MAJOR_VERSION" >> $GITHUB_OUTPUT
 
       - name: Retag major version
         run: |


### PR DESCRIPTION
> [Update the major tag to include the 1.1.0 changes](https://github.com/FriendsOfREDAXO/installer-action/actions/runs/4518422389/jobs/7958292937#step:4:8)
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/