### PR TITLE
MyRedaxo: add fallback for failed package requests

### DIFF
--- a/__tests__/myRedaxo.test.ts
+++ b/__tests__/myRedaxo.test.ts
@@ -1,16 +1,21 @@
-import {fetchAddonPackageYml, versionExists} from "../src/myRedaxo";
+import {fetchAddonPackageData, versionExists} from "../src/myRedaxo";
 
 const testMyRedaxoPackage = require('./data/myRedaxoPackage.json');
 
 describe('myRedaxo', () => {
     describe('fetchAddon',  () => {
         test('should error with 404', async () => {
-            const packageYml = await fetchAddonPackageYml('non_existing_addon');
+            const packageYml = await fetchAddonPackageData('non_existing_addon');
 
             expect(packageYml).toBe(null);
         });
         test('should return addon data', async () => {
-            const packageYml = await fetchAddonPackageYml('yform');
+            const packageYml = await fetchAddonPackageData('yform');
+
+            expect(packageYml).toHaveProperty('name');
+        });
+        test('should use fallback', async () => {
+            const packageYml = await fetchAddonPackageData('multinewsletter');
 
             expect(packageYml).toHaveProperty('name');
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import * as Core from '@actions/core';
 import {md5_file, readPackageYml, validatePackageVersion} from "./package";
 import {cacheFile, zip} from "./file";
-import {fetchAddonPackageYml, uploadArchive, versionExists} from "./myRedaxo";
+import {fetchAddonPackageData, uploadArchive, versionExists} from "./myRedaxo";
 
 const packageDir = Core.getInput('cwd');
 const archiveFilePath = cacheFile();
@@ -23,7 +23,7 @@ const archiveFilePath = cacheFile();
             return;
         }
 
-        const existingPackageYml = await fetchAddonPackageYml(packageName, myRedaxoUsername, myRedaxoApiKey);
+        const existingPackageYml = await fetchAddonPackageData(packageName, myRedaxoUsername, myRedaxoApiKey);
         if (!existingPackageYml) {
             Core.setFailed(`Could not fetch addon ${packageName}. Please check your addon key and your MyRedaxo credentials.`);
             return;


### PR DESCRIPTION
fixes https://github.com/FriendsOfREDAXO/installer-action/issues/160

```
GET https://www.redaxo.org/de/ws/packages/multinewsletter/

{
    "error": "Die package.yml fehlt!"
}
```

Es gibt Versionen ohne `package.yml` weshalb das parsing der YAML im Webservice fehlschlägt.
Als Fallback nutzen wir die normale packages list.
