### PR TITLE
Ignorierte Verzeichnisse komplett aus dem Archiv ausschliessen

### DIFF
--- a/__tests__/data/test-addon/.github/workflows/publish-to-redaxo.yml
+++ b/__tests__/data/test-addon/.github/workflows/publish-to-redaxo.yml
@@ -1,0 +1,7 @@
+name: Publish release
+
+# Fixture only: this file must never end up in the generated archive.
+on:
+    release:
+        types:
+            - published

--- a/dist/index.js
+++ b/dist/index.js
@@ -60633,7 +60633,7 @@ async function zip(cacheFile, addonDir, addonName, ignoreList) {
     archive.on('entry', (entry) => {
         Core.info(`Adding to zip: ${entry.name}`);
     });
-    archive.glob('**', { cwd: addonDir, ignore: combinedIgnoreList, dot: true }, { prefix: addonName });
+    archive.glob('**', { cwd: addonDir, skip: combinedIgnoreList, ignore: combinedIgnoreList, dot: true }, { prefix: addonName });
     return await new Promise(async (resolve, reject) => {
         output.on('error', (err) => {
             Core.setFailed(err.message);

--- a/src/file.ts
+++ b/src/file.ts
@@ -22,7 +22,7 @@ export async function zip(cacheFile: string, addonDir: string, addonName: string
         Core.info(`Adding to zip: ${entry.name}`);
     });
 
-    archive.glob('**', { cwd: addonDir, ignore: combinedIgnoreList, dot: true }, { prefix: addonName });
+    archive.glob('**', { cwd: addonDir, skip: combinedIgnoreList, ignore: combinedIgnoreList, dot: true }, { prefix: addonName });
 
     // we need to manually check if the zip archive is finalized
     // see https://github.com/archiverjs/node-archiver/blob/b5cc14cc97cc64bdca32c0cbe9d660b5b979be7c/lib/core.js#L760-L769


### PR DESCRIPTION
Seit dem Wegfall der `skip`-Option in #391 landen ignorierte Verzeichnisse wieder im Paket. `ignore` und `skip` haben in `readdir-glob` unterschiedliche Aufgaben:

* `ignore`: *"If a file or a folder matches at least one of the provided patterns, it's not returned. **It doesn't prevent files from folder content to be returned.**"*
* `skip`: *"If a folder matches one of the provided patterns, it's not returned, **and it's not explored: this prevents any of its children to be returned.**"*

Ein Muster wie `.git` matcht also den Verzeichnis-Eintrag selbst — der fliegt raus —, `readdir-glob` steigt aber weiter ab und alle Dateien darunter wandern ins ZIP. Deshalb wird `skip` wieder gesetzt.

Das früher dafür nötige `@ts-ignore` entfällt: `@types/readdir-glob@1.1.5` deklariert `skip?: string | string[]`, erreichbar über `type GlobOptions = ReaddirGlob.Options & { cwd?: string }` in `@types/archiver@6.0.4`. `tsc --noEmit` läuft sauber durch.

Die Test-Fixture bekommt ein `.github/workflows/`-Verzeichnis, damit der bestehende Dateilisten-Test den Fall abdeckt. Gegenprobe ohne `skip`: die Action protokolliert `Adding to zip: test_addon/.github/workflows/publish-to-redaxo.yml` und der Test wird rot. Mit `skip` wird das Verzeichnis nicht betreten.
