### PR TITLE
Ziffer und Unterstrich am Anfang des Paketschlüssels zulassen

### DIFF
--- a/__tests__/package.test.ts
+++ b/__tests__/package.test.ts
@@ -32,6 +32,22 @@ describe('package', () => {
             expect(() => validateRedaxoAddon(packageYml, TEST_PACKAGE_PATH)).not.toThrow();
         });
 
+        test('should accept a package key starting with a digit or an underscore', () => {
+            const packageYml = {
+                package: 'valid_addon',
+                version: '1.0.0',
+                installer_ignore: null,
+                requires: {
+                    redaxo: '^5.0.0',
+                },
+            };
+
+            expect(() => validateRedaxoAddon({...packageYml, package: '2nd_addon'}, TEST_PACKAGE_PATH)).not.toThrow();
+            expect(() => validateRedaxoAddon({...packageYml, package: '_addon'}, TEST_PACKAGE_PATH)).not.toThrow();
+            expect(() => validateRedaxoAddon({...packageYml, package: '404'}, TEST_PACKAGE_PATH)).not.toThrow();
+            expect(() => validateRedaxoAddon({...packageYml, package: '_'}, TEST_PACKAGE_PATH)).not.toThrow();
+        });
+
         test('should fail for invalid package key', () => {
             const packageYml = {
                 package: 'Invalid-Key',
@@ -42,6 +58,11 @@ describe('package', () => {
                 },
             };
             expect(() => validateRedaxoAddon(packageYml, TEST_PACKAGE_PATH)).toThrow('Invalid package key');
+
+            expect(() => validateRedaxoAddon({...packageYml, package: 'UpperCase'}, TEST_PACKAGE_PATH)).toThrow('Invalid package key');
+            expect(() => validateRedaxoAddon({...packageYml, package: 'with space'}, TEST_PACKAGE_PATH)).toThrow('Invalid package key');
+            expect(() => validateRedaxoAddon({...packageYml, package: 'with.dot'}, TEST_PACKAGE_PATH)).toThrow('Invalid package key');
+            expect(() => validateRedaxoAddon({...packageYml, package: ''}, TEST_PACKAGE_PATH)).toThrow('Invalid package key');
         });
 
         test('should fail if requires.redaxo is missing', () => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -12264,6 +12264,20 @@ var escClose = '\0CLOSE'+Math.random()+'\0';
 var escComma = '\0COMMA'+Math.random()+'\0';
 var escPeriod = '\0PERIOD'+Math.random()+'\0';
 
+var EXPANSION_MAX = 100000
+
+// `EXPANSION_MAX` caps the *number* of expansions, but not their length. An
+// input like `'{a,b}'.repeat(1500)` stays under that count - its output is
+// truncated to 100k results - while making every result ~1500 characters
+// long. The result set, and the intermediate arrays built while combining
+// brace sets, then grow large enough to exhaust memory and crash the process
+// (CVE-2026-14257). `EXPANSION_MAX_LENGTH` bounds the total number of
+// characters the accumulator may hold at any point, so memory stays flat no
+// matter how many brace groups are chained. The limit sits well above any
+// realistic expansion (100k results hitting `EXPANSION_MAX` measure ~1M
+// characters) so legitimate input is unaffected.
+var EXPANSION_MAX_LENGTH = 4000000
+
 function numeric(str) {
   return parseInt(str, 10) == str
     ? parseInt(str, 10)
@@ -12322,7 +12336,8 @@ function expandTop(str, options) {
     return [];
 
   options = options || {};
-  var max = options.max == null ? Infinity : options.max;
+  var max = options.max == null ? EXPANSION_MAX : options.max;
+  var maxLength = options.maxLength == null ? EXPANSION_MAX_LENGTH : options.maxLength;
 
   // I don't know why Bash 4.3 does this, but it does.
   // Anything starting with {} will have the first two bytes preserved
@@ -12334,7 +12349,7 @@ function expandTop(str, options) {
     str = '\\{\\}' + str.substr(2);
   }
 
-  return expand(escapeBraces(str), max, true).map(unescapeBraces);
+  return expand(escapeBraces(str), max, maxLength, true).map(unescapeBraces);
 }
 
 function embrace(str) {
@@ -12351,27 +12366,142 @@ function gte(i, y) {
   return i >= y;
 }
 
-function expand(str, max, isTop) {
-  var expansions = [];
+// Build `{ acc[a] + pre + values[v] }` for every combination, capping the
+// number of results at `max` and the total number of characters at `maxLength`.
+// This is the one place output grows, so bounding it here keeps the single
+// accumulator - and therefore memory - flat regardless of how many brace groups
+// are combined (CVE-2026-14257).
+function combine(
+  acc,
+  pre,
+  values,
+  max,
+  maxLength,
+  dropEmpties
+) {
+  var out = []
+  var length = 0
+  for (var a = 0; a < acc.length; a++) {
+    for (var v = 0; v < values.length; v++) {
+      if (out.length >= max) return out
+      var expansion = acc[a] + pre + values[v]
+      // Bash drops empty results at the top level. Skip them before they count
+      // against `max`, so `max` bounds the number of *kept* results.
+      if (dropEmpties && !expansion) continue
+      if (length + expansion.length > maxLength) return out
+      out.push(expansion)
+      length += expansion.length
+    }
+  }
+  return out
+}
 
-  // The `{a},b}` rewrite below restarts expansion on a rewritten string with
-  // the same `max` and `isTop = true`. Loop instead of recursing so a long run
-  // of non-expanding `{}` groups can't exhaust the call stack.
+// The expansion values of a single numeric (`1..5`) or alphabetic (`a..e..2`)
+// sequence body.
+function expandSequence(
+  body,
+  isAlphaSequence,
+  max,
+  maxLength
+) {
+  var n = body.split(/\.\./)
+  var N = []
+  // A sequence body always splits into two or three parts, but the compiler
+  // can't know that.
+  /* c8 ignore start */
+  if (n[0] === undefined || n[1] === undefined) {
+    return N
+  }
+  /* c8 ignore stop */
+  var x = numeric(n[0])
+  var y = numeric(n[1])
+  var width = Math.max(n[0].length, n[1].length)
+  var incr =
+    n.length === 3 && n[2] !== undefined ?
+      Math.max(Math.abs(numeric(n[2])), 1)
+    : 1
+  var test = lte
+  var reverse = y < x
+  if (reverse) {
+    incr *= -1
+    test = gte
+  }
+  var pad = n.some(isPadded)
+
+  var length = 0
+  for (var i = x; test(i, y) && N.length < max; i += incr) {
+    var c
+    if (isAlphaSequence) {
+      c = String.fromCharCode(i)
+      if (c === '\\') {
+        c = ''
+      }
+    } else {
+      c = String(i)
+      if (pad) {
+        var need = width - c.length
+        if (need > 0) {
+          var z = new Array(need + 1).join('0')
+          if (i < 0) {
+            c = '-' + z + c.slice(1)
+          } else {
+            c = z + c
+          }
+        }
+      }
+    }
+    if (length + c.length > maxLength) break
+    N.push(c)
+    length += c.length
+  }
+  return N
+}
+
+function expand(
+  str,
+  max,
+  maxLength,
+  isTop
+) {
+  // Consume the string's top-level brace groups left to right, threading a
+  // running set of combined prefixes (`acc`). Expanding the tail iteratively -
+  // rather than recursing on `m.post` once per group - keeps the native stack
+  // depth constant, so deeply chained input (`'{a,b}'.repeat(3000)`) can no
+  // longer overflow the stack, and leaves a single accumulator whose size
+  // `maxLength` bounds directly (CVE-2026-14257).
+  var acc = ['']
+
+  // Bash drops empty results, but only when the *first* top-level group is a
+  // comma set - a sequence like `{a..\}` may legitimately yield ''. The drop
+  // is on the final strings, so it is applied to whichever `combine` produces
+  // them (the one with no brace set left in the tail).
+  var dropEmpties = false
+  var firstGroup = true
+
   for (;;) {
     const m = balanced('{', '}', str)
-    if (!m) return [str]
+
+    // No brace set left: the rest of the string is literal.
+    if (!m) {
+      return combine(acc, str, [''], max, maxLength, dropEmpties)
+    }
 
     // no need to expand pre, since it is guaranteed to be free of brace-sets
     const pre = m.pre
 
-    if (/\$$/.test(m.pre)) {
-      const post =
-        m.post.length ? expand(m.post, max, false) : ['']
-      for (let k = 0; k < post.length && k < max; k++) {
-        const expansion = pre + '{' + m.body + '}' + post[k]
-        expansions.push(expansion)
-      }
-      return expansions
+    if (/\$$/.test(pre)) {
+      acc = combine(
+        acc,
+        pre + '{' + m.body + '}',
+        [''],
+        max,
+        maxLength,
+        dropEmpties && !m.post.length
+      )
+      firstGroup = false
+      if (!m.post.length) break
+      str = m.post
+      continue
     }
 
     var isNumericSequence = /^-?\d+\.\.-?\d+(?:\.\.-?\d+)?$/.test(m.body);
@@ -12385,91 +12515,82 @@ function expand(str, max, isTop) {
         isTop = true;
         continue;
       }
-      return [str];
+      // Nothing here expands, so the whole remaining string is literal.
+      return combine(
+        acc,
+        pre + '{' + m.body + '}' + m.post,
+        [''],
+        max,
+        maxLength,
+        dropEmpties
+      )
     }
 
-    // Only expand post once we know this brace set actually expands. Computing
-    // it before the early returns above expanded post a second time on every
-    // non-expanding `{}`, which is what made inputs like `a{},{},{}...` blow up
-    // exponentially.
-    const post =
-      m.post.length ? expand(m.post, max, false) : ['']
-    var n;
+    if (firstGroup) {
+      dropEmpties = isTop && !isSequence
+      firstGroup = false
+    }
+
+    var values;
     if (isSequence) {
-      n = m.body.split(/\.\./);
+      values = expandSequence(m.body, isAlphaSequence, max, maxLength);
     } else {
-      n = parseCommaParts(m.body);
-      if (n.length === 1) {
+      var n = parseCommaParts(m.body);
+      if (n.length === 1 && n[0] !== undefined) {
         // x{{a,b}}y ==> x{a}y x{b}y
-        n = expand(n[0], max, false).map(embrace);
+        n = expand(n[0], max, maxLength, false).map(embrace);
+        //XXX is this necessary? Can't seem to hit it in tests.
+        /* c8 ignore start */
         if (n.length === 1) {
-          return post.map(function(p) {
-            return m.pre + n[0] + p;
-          });
+          acc = combine(
+            acc,
+            pre + n[0],
+            [''],
+            max,
+            maxLength,
+            dropEmpties && !m.post.length
+          )
+          if (!m.post.length) break
+          str = m.post
+          continue
+        }
+        /* c8 ignore stop */
+      }
+
+      // Values that `combine` is going to drop as empty produce no result, so
+      // they must not count against `max` - otherwise `{a,,b}` with `max: 2`
+      // would stop at `['a', '']` and yield one result instead of two. Skipping
+      // them outright keeps `values` bounded while leaving `max` a bound on
+      // *kept* results.
+      var dropsEmpties = dropEmpties && !m.post.length && !pre
+      for (var d = 0; dropsEmpties && d < acc.length; d++) {
+        if (acc[d]) {
+          dropsEmpties = false
         }
       }
-    }
 
-    // at this point, n is the parts, and we know it's not a comma set
-    // with a single entry.
-    var N;
-
-    if (isSequence) {
-      var x = numeric(n[0]);
-      var y = numeric(n[1]);
-      var width = Math.max(n[0].length, n[1].length)
-      var incr = n.length == 3
-        ? Math.max(Math.abs(numeric(n[2])), 1)
-        : 1;
-      var test = lte;
-      var reverse = y < x;
-      if (reverse) {
-        incr *= -1;
-        test = gte;
-      }
-      var pad = n.some(isPadded);
-
-      N = [];
-
-      for (var i = x; test(i, y) && N.length < max; i += incr) {
-        var c;
-        if (isAlphaSequence) {
-          c = String.fromCharCode(i);
-          if (c === '\\')
-            c = '';
-        } else {
-          c = String(i);
-          if (pad) {
-            var need = width - c.length;
-            if (need > 0) {
-              var z = new Array(need + 1).join('0');
-              if (i < 0)
-                c = '-' + z + c.slice(1);
-              else
-                c = z + c;
-            }
+      values = []
+      var valuesLength = 0
+      outer: for (var j = 0; j < n.length; j++) {
+        var expanded = expand(n[j], max, maxLength, false)
+        for (var k = 0; k < expanded.length; k++) {
+          var v = expanded[k]
+          if (dropsEmpties && !v) continue
+          if (values.length >= max || valuesLength + v.length > maxLength) {
+            break outer
           }
+          values.push(v)
+          valuesLength += v.length
         }
-        N.push(c);
-      }
-    } else {
-      N = [];
-
-      for (var j = 0; j < n.length; j++) {
-        N.push.apply(N, expand(n[j], max, false));
       }
     }
 
-    for (var j = 0; j < N.length; j++) {
-      for (var k = 0; k < post.length && expansions.length < max; k++) {
-        var expansion = pre + N[j] + post[k];
-        if (!isTop || isSequence || expansion)
-          expansions.push(expansion);
-      }
-    }
-
-    return expansions;
+    acc = combine(acc, pre, values, max, maxLength, dropEmpties && !m.post.length)
+    if (!m.post.length) break
+    str = m.post
   }
+
+  return acc
 }
 
 
@@ -61009,8 +61130,8 @@ function validateRedaxoAddon(packageYml, addonDir) {
     if (!packageYml || 'object' !== typeof packageYml) {
         throw new Error('Invalid package.yml content.');
     }
-    if (!packageYml.package || !/^[a-z][a-z0-9_]*$/.test(packageYml.package)) {
-        throw new Error('Invalid package key in package.yml. Expected format: lowercase letters, digits and underscores, starting with a letter.');
+    if (!packageYml.package || !/^[a-z0-9_]+$/.test(packageYml.package)) {
+        throw new Error('Invalid package key in package.yml. Expected format: lowercase letters, digits and underscores.');
     }
     if (!packageYml.version || 'string' !== typeof packageYml.version) {
         throw new Error('Invalid or missing version in package.yml.');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@friendsofredaxo/installer-action",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@friendsofredaxo/installer-action",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@friendsofredaxo/installer-action",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "MyREDAXO for GitHub Actions",
   "main": "lib/index.js",
   "scripts": {

--- a/src/package.ts
+++ b/src/package.ts
@@ -67,8 +67,8 @@ export function validateRedaxoAddon(packageYml: PackageYml, addonDir: string): v
         throw new Error('Invalid package.yml content.');
     }
 
-    if (!packageYml.package || !/^[a-z][a-z0-9_]*$/.test(packageYml.package)) {
-        throw new Error('Invalid package key in package.yml. Expected format: lowercase letters, digits and underscores, starting with a letter.');
+    if (!packageYml.package || !/^[a-z0-9_]+$/.test(packageYml.package)) {
+        throw new Error('Invalid package key in package.yml. Expected format: lowercase letters, digits and underscores.');
     }
 
     if (!packageYml.version || 'string' !== typeof packageYml.version) {


### PR DESCRIPTION
Behebt #408.

## Problem

Die mit 1.3.0 eingeführte Namensprüfung in `src/package.ts` verlangt einen Buchstaben an erster Stelle:

```ts
if (!packageYml.package || !/^[a-z][a-z0-9_]*$/.test(packageYml.package)) {
```

REDAXO selbst kennt keine solche Einschränkung. Der Paketschlüssel ist der Verzeichnisname unter `redaxo/src/addons/`, und der Core prüft ihn gegen kein Muster — weder beim Laden noch bei der Installation. Die Action ist damit strenger als das System, für das sie veröffentlicht.

Praktisch heißt das: AddOns, deren Name mit einer Ziffer oder einem Unterstrich beginnt, lassen sich seit 1.3.0 nicht mehr hochladen. Betroffen sind auch AddOns, die über frühere Versionen der Action bereits auf redaxo.org veröffentlicht wurden — für die ist der Weg zu einem Update jetzt zu. Gegenüber 1.2.0 ist das eine Regression.

## Änderung

```diff
-if (!packageYml.package || !/^[a-z][a-z0-9_]*$/.test(packageYml.package)) {
-    throw new Error('Invalid package key in package.yml. Expected format: lowercase letters, digits and underscores, starting with a letter.');
+if (!packageYml.package || !/^[a-z0-9_]+$/.test(packageYml.package)) {
+    throw new Error('Invalid package key in package.yml. Expected format: lowercase letters, digits and underscores.');
```

Die drei erlaubten Zeichenklassen bleiben dieselben, nur die Sonderregel für das erste Zeichen fällt weg. Die Fehlermeldung beschreibt danach genau das, was der Ausdruck prüft.

Weiterhin abgewiesen werden Großbuchstaben, Bindestriche, Punkte, Leerzeichen und ein leerer Schlüssel. Die Tests in `__tests__/package.test.ts` decken beide Seiten ab:

| akzeptiert | abgewiesen |
|---|---|
| `2nd_addon` | `Invalid-Key` |
| `_addon` | `UpperCase` |
| `404` | `with space` |
| `_` | `with.dot` |
| | `''` |

Der neue Positivtest schlägt sowohl gegen den bisherigen Ausdruck als auch gegen eine Variante fehl, die nur Ziffern vorn erlaubt — gegengeprüft, nicht nur behauptet.

## Zum Umfang

Ob auch Großbuchstaben erlaubt sein sollten, ist eine eigene Frage. Es gibt AddOns mit gemischter Schreibweise im Schlüssel, die weiterhin abgewiesen werden. Das bewusst nicht in diesem PR, damit die Änderung klein und begründbar bleibt.

## Hinweise zum Diff

**`dist/index.js` enthält mehr als diese Änderung.** In #405 wurde `brace-expansion` in der Lockfile angehoben, das Bundle aber nicht neu gebaut — der Fix zu CVE-2026-14257 steckt deshalb bis heute nicht in dem, was `v1` ausliefert. Der Rebuild hier zieht ihn mit. Über `validateRedaxoAddon` hinaus sind im Bundle ausschließlich `expand`, `expandTop`, `gte` und `escPeriod` aus `brace-expansion` betroffen; ich habe die Hunks einzeln durchgesehen.

**Version** auf 1.3.2 angehoben, analog zu #404.

**Gebaut mit Node 26**, die CI baut mit 24. Das ncc-Ergebnis hängt an den Versionen aus der Lockfile, nicht an der Laufzeit; falls ihr auf Bit-Gleichheit Wert legt, baue ich gern unter 24 nach.

---
*Dieser Text wurde KI-generiert.*
